### PR TITLE
Use OpenRouter for meaning translations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,8 +90,8 @@ npm run preview
 * `WORKER_BASE = https://wordworker.../define?word=`：Cloudflare Worker（返回 `{ meaning, etymology }`）。
 * 若无释义，回退到 **DictionaryAPI**：`https://api.dictionaryapi.dev/...`
 
-  * 若只拿到英文释义，会通过 **Google Translate（免费接口）** 翻到中文：
-    `TRANSLATE_PROXY_BASE = https://cors-header-proxy.../corsproxy?apiurl=...`
+  * 若只拿到英文释义，会通过 **OpenRouter AI 翻译**（`openai/gpt-5-nano`）转成中文：
+    需在运行环境中设置 `VITE_OPENROUTER_API_KEY`
 * 还配置了 `GLOSBE_WORKER_BASE` 作为另一层兜底。
 
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- replace the Google Translate worker fallback with an OpenRouter GPT translation request and prepend the required Chinese instruction prompt
- add Vite env typings and document the new VITE_OPENROUTER_API_KEY requirement in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0f895afe48333af9cc203b61665d2